### PR TITLE
Movimentação do Inimigo

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -150144,13 +150144,21 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2833729022764188264, guid: 546878aa203a1624eaeb584c3253a935, type: 3}
+      propertyPath: radius
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2833729022764188264, guid: 546878aa203a1624eaeb584c3253a935, type: 3}
+      propertyPath: layer.m_Bits
+      value: 256
+      objectReference: {fileID: 0}
     - target: {fileID: 3925209387398030987, guid: 546878aa203a1624eaeb584c3253a935, type: 3}
       propertyPath: m_Name
       value: Skeleton
       objectReference: {fileID: 0}
     - target: {fileID: 3925209387398030987, guid: 546878aa203a1624eaeb584c3253a935, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7056839803980325607, guid: 546878aa203a1624eaeb584c3253a935, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scripts/Enemy/Skeleton.cs
+++ b/Assets/Scripts/Enemy/Skeleton.cs
@@ -8,6 +8,8 @@ public class Skeleton : MonoBehaviour
 {
 
     [Header("Stats")]
+    public float radius;
+    public LayerMask layer;
     public float totalHealth;
     public float currentHealth;
     public Image heathBar;
@@ -18,6 +20,8 @@ public class Skeleton : MonoBehaviour
     [SerializeField] private AnimationControl animControl;
 
     private Player player;
+    private bool detectPlayer;
+
 
     // Start is called before the first frame update
     void Start()
@@ -31,8 +35,9 @@ public class Skeleton : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (!isDead)
+        if (!isDead && detectPlayer)
         {
+            agent.isStopped = false;
             agent.SetDestination(player.transform.position);
 
             if (Vector2.Distance(transform.position, player.transform.position) <= agent.stoppingDistance)
@@ -57,5 +62,34 @@ public class Skeleton : MonoBehaviour
                 transform.eulerAngles = new Vector2(0, 180);
             }
         }
+       
+    }
+
+    private void FixedUpdate()
+    {
+        DetectPlayer();
+    }
+
+    public void DetectPlayer()
+    {
+        Collider2D hit = Physics2D.OverlapCircle(transform.position, radius, layer);
+
+        if(hit != null)
+        {
+            //enxergou o player
+            detectPlayer = true;
+        }
+        else
+        {
+            //Não está vendo o player
+            detectPlayer= false;
+            animControl.PlayAnim(0);
+            agent.isStopped = true;
+        }
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.DrawWireSphere(transform.position, radius);
     }
 }


### PR DESCRIPTION
Ajuste para inimigo identificar aproximação do player.

BUG NO NAVMESH AO CLICAR EM NO "BAKE", ANULA TODOS OS EVENTOS DOS INIMIGOS, pode realizar todas as operações e não clicar para que funcione normalmente.